### PR TITLE
Hotfix bintray

### DIFF
--- a/Domino_Analytics_Distribution/latest/Dockerfile
+++ b/Domino_Analytics_Distribution/latest/Dockerfile
@@ -335,3 +335,6 @@ RUN apt-get clean && \
 RUN rm -rf /home/ubuntu/.cache/coursier
 # Removing PyYAML due to security vulnerabilities. Was not pip installed, so removing manually
 RUN rm -rf /opt/conda/lib/python3.8/site-packages/PyYAML-5.3.1.dist-info /opt/conda/lib/python3.8/site-packages/PyYAML-5.3.1-py3.8.egg-info
+
+# Bintray no longer exists as of July 4th, so adding this line to document fix for bintray related apt-get issues
+RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/Dockerfile.cuda10_1
+++ b/Domino_Analytics_Distribution/latest/Dockerfile.cuda10_1
@@ -405,3 +405,6 @@ RUN apt-get clean && \
 RUN rm -rf /home/ubuntu/.cache/coursier
 # Removing PyYAML due to security vulnerabilities. Was not pip installed, so removing manually
 RUN rm -rf /opt/conda/lib/python3.8/site-packages/PyYAML-5.3.1.dist-info /opt/conda/lib/python3.8/site-packages/PyYAML-5.3.1-py3.8.egg-info
+
+# Bintray no longer exists as of July 4th, so adding this line to document fix for bintray related apt-get issues
+RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/Dockerfile.cuda11
+++ b/Domino_Analytics_Distribution/latest/Dockerfile.cuda11
@@ -404,3 +404,6 @@ RUN apt-get clean && \
 RUN rm -rf /home/ubuntu/.cache/coursier
 # Removing PyYAML due to security vulnerabilities. Was not pip installed, so removing manually
 RUN rm -rf /opt/conda/lib/python3.8/site-packages/PyYAML-5.3.1.dist-info /opt/conda/lib/python3.8/site-packages/PyYAML-5.3.1-py3.8.egg-info
+
+# Bintray no longer exists as of July 4th, so adding this line to document fix for bintray related apt-get issues
+RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/Dockerfile.cuda11.full
+++ b/Domino_Analytics_Distribution/latest/Dockerfile.cuda11.full
@@ -387,3 +387,6 @@ RUN apt-get clean && \
 RUN rm -rf /home/ubuntu/.cache/coursier
 # Removing PyYAML due to security vulnerabilities. Was not pip installed, so removing manually
 RUN rm -rf /opt/conda/lib/python3.8/site-packages/PyYAML-5.3.1.dist-info /opt/conda/lib/python3.8/site-packages/PyYAML-5.3.1-py3.8.egg-info
+
+# Bintray no longer exists as of July 4th, so adding this line to document fix for bintray related apt-get issues
+RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/Dockerfile.spark
+++ b/Domino_Analytics_Distribution/latest/Dockerfile.spark
@@ -360,3 +360,6 @@ RUN apt-get clean && \
 RUN rm -rf /home/ubuntu/.cache/coursier
 # Removing PyYAML due to security vulnerabilities. Was not pip installed, so removing manually
 RUN rm -rf /opt/conda/lib/python3.8/site-packages/PyYAML-5.3.1.dist-info /opt/conda/lib/python3.8/site-packages/PyYAML-5.3.1-py3.8.egg-info
+
+# Bintray no longer exists as of July 4th, so adding this line to document fix for bintray related apt-get issues
+RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile
+++ b/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile
@@ -1,2 +1,2 @@
-FROM Ubuntu18_DAD_Py3.8_R4.0-20210503_noCUDA
+FROM quay.io/domino/base:Ubuntu18_DAD_Py3.8_R4.0-20210503_noCUDA
 RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile
+++ b/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile
@@ -1,0 +1,2 @@
+FROM Ubuntu18_DAD_Py3.8_R4.0-20210503_noCUDA
+RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda10_1
+++ b/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda10_1
@@ -1,2 +1,2 @@
-FROM Ubuntu18_DAD_Py3.8_R4.0-20210503_CUDA10.1
+FROM quay.io/domino/base:Ubuntu18_DAD_Py3.8_R4.0-20210503_CUDA10.1
 RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda10_1
+++ b/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda10_1
@@ -1,0 +1,2 @@
+FROM Ubuntu18_DAD_Py3.8_R4.0-20210503_CUDA10.1
+RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda11
+++ b/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda11
@@ -1,2 +1,2 @@
-FROM Ubuntu18_DAD_Py3.8_R4.0-20210503_CUDA11
+FROM quay.io/domino/base:Ubuntu18_DAD_Py3.8_R4.0-20210503_CUDA11
 RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda11
+++ b/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda11
@@ -1,0 +1,2 @@
+FROM Ubuntu18_DAD_Py3.8_R4.0-20210503_CUDA11
+RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda11.full
+++ b/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda11.full
@@ -1,0 +1,2 @@
+FROM Ubuntu18_DAD_Py3.8_R4.0-20210503_CUDA11_full
+RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda11.full
+++ b/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.cuda11.full
@@ -1,2 +1,2 @@
-FROM Ubuntu18_DAD_Py3.8_R4.0-20210503_CUDA11_full
+FROM quay.io/domino/base:Ubuntu18_DAD_Py3.8_R4.0-20210503_CUDA11_full
 RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.spark
+++ b/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.spark
@@ -1,0 +1,2 @@
+FROM Ubuntu18_DAD_Py3.8_R4.0-20210503_Spark3.1
+RUN rm -rf /etc/apt/sources.list.d/sbt.list

--- a/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.spark
+++ b/Domino_Analytics_Distribution/latest/fix-bintray/Dockerfile.spark
@@ -1,2 +1,2 @@
-FROM Ubuntu18_DAD_Py3.8_R4.0-20210503_Spark3.1
+FROM quay.io/domino/base:Ubuntu18_DAD_Py3.8_R4.0-20210503_Spark3.1
 RUN rm -rf /etc/apt/sources.list.d/sbt.list


### PR DESCRIPTION
Bintray stopped existing as of July 4th, 2021. We installed scala via bintray and added it as an `apt-get` source, causing issues when users tried to `apt-get upgrade` on top of a DAD image. 

This PR includes a directory for the fix applied to images so bintray is no longer a source and `apt-get` can work correctly. While the existing dockerfiles are updated with this fix as well for documentation purposes, these dockerfiles still include bintray and will not run.

This should not be a long term issue now that we are switching over to a template based build system.